### PR TITLE
Add responseUrl to result object

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ probe('http://example.com/image.jpg', function (err, result) {
       type: 'jpg',
       mime: 'image/jpeg',
       wUnits: 'px',
-      hUnits: 'px'
+      hUnits: 'px',
+      url: 'http://example.com/image.jpg'
     }
   */
 });
@@ -100,6 +101,7 @@ API
   mime: ...,  // mime type
   wUnits: 'px', // width units type ('px' by default, can be different for SVG)
   hUnits: 'px', // height units type ('px' by default, can be different for SVG)
+  url: ..., // last url for the image in chain of redirects (if no redirects, same as src) (HTTP only)
 }
 ```
 

--- a/http.js
+++ b/http.js
@@ -37,6 +37,8 @@ module.exports = function probeHttp(options, _callback) {
           if (length && length.match(/^\d+$/)) {
             result.length = +length;
           }
+
+          result.url = res.request.uri.href;
         }
 
         callback(err, result);

--- a/test/http.js
+++ b/test/http.js
@@ -157,4 +157,11 @@ describe('probeHttp', function () {
         assert.equal(size.height, 539);
       });
   });
+
+  it('should return url', function () {
+    return probe('https://dm.victoriassecret.com/product/404x539/V588032.jpg')
+      .then(function (size) {
+        assert.equal(size.url, 'https://dm.victoriassecret.com/product/404x539/V588032.jpg');
+      });
+  });
 });


### PR DESCRIPTION
We've had a use-case recently where it's helpful to also retrieve the url of the image after any redirects have been followed – since redirects are already being followed, it was just a matter of returning one additional piece of data that was already available, at no cost. Hope that feels like a great addition, thanks for the great tool!