### PR TITLE
Don't use any-promise

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,6 +1,7 @@
 env:
   node:     true
   browser:  false
+  es6:      true
 
 rules:
   accessor-pairs:         2

--- a/http.js
+++ b/http.js
@@ -17,14 +17,8 @@ var defaults = {
   }
 };
 
-var P;
-
-
 module.exports = function probeHttp(src, options) {
-  // lazy Promise init
-  P = P || require('any-promise');
-
-  return new P(function (resolve, reject) {
+  return new Promise(function (resolve, reject) {
     var req, length, finalUrl;
 
     try {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "report-coveralls": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
   },
   "dependencies": {
-    "any-promise": "^1.3.0",
     "deepmerge": "^2.0.1",
     "inherits": "^2.0.3",
     "next-tick": "^1.0.0",

--- a/stream.js
+++ b/stream.js
@@ -5,17 +5,12 @@ var ProbeError  = require('./lib/common').ProbeError;
 var parsers     = require('./lib/parsers_stream');
 var PassThrough = require('stream').PassThrough;
 
-var P;
-
 
 module.exports = function probeStream(stream) {
-  // lazy Promise init
-  P = P || require('any-promise');
-
   var proxy = new PassThrough();
   var cnt = 0; // count of working parsers
 
-  var result = new P(function (resolve, reject) {
+  var result = new Promise(function (resolve, reject) {
     stream.on('error', reject);
     proxy.on('error', reject);
 


### PR DESCRIPTION
Don't think there's a reason to use this nowadays. Even https://github.com/kevinbeaty/any-promise says to use native promises.

Sending this out because I got this error in Mocha:
```
Error: global leak detected: '@@any-promise/REGISTRATION'
```