### PR TITLE
Fix re for svg width to exclude stroke-width

### DIFF
--- a/lib/parse_stream/svg.js
+++ b/lib/parse_stream/svg.js
@@ -12,7 +12,7 @@ var STATE_IGNORE    = 2; // we got all the data we want, skip the rest
 var MAX_DATA_LENGTH = 65536;
 
 var SVG_HEADER_RE  = /<svg\s[^>]+>/;
-var SVG_WIDTH_RE   = /\bwidth="([^%]+?)"|\bwidth='([^%]+?)'/;
+var SVG_WIDTH_RE   = /[^-]\bwidth="([^%]+?)"|[^-]\bwidth='([^%]+?)'/;
 var SVG_HEIGHT_RE  = /\bheight="([^%]+?)"|\bheight='([^%]+?)'/;
 var SVG_VIEWBOX_RE = /\bview[bB]ox="(.+?)"|\bview[bB]ox='(.+?)'/;
 var SVG_UNITS_RE   = /in$|mm$|cm$|pt$|pc$|px$|em$|ex$/;

--- a/lib/parse_sync/svg.js
+++ b/lib/parse_sync/svg.js
@@ -22,7 +22,7 @@ function canBeSvg(buf) {
 
 
 var SVG_HEADER_RE  = /<svg\s[^>]+>/;
-var SVG_WIDTH_RE   = /\bwidth="([^%]+?)"|\bwidth='([^%]+?)'/;
+var SVG_WIDTH_RE   = /[^-]\bwidth="([^%]+?)"|[^-]\bwidth='([^%]+?)'/;
 var SVG_HEIGHT_RE  = /\bheight="([^%]+?)"|\bheight='([^%]+?)'/;
 var SVG_VIEWBOX_RE = /\bview[bB]ox="(.+?)"|\bview[bB]ox='(.+?)'/;
 var SVG_UNITS_RE   = /in$|mm$|cm$|pt$|pc$|px$|em$|ex$/;

--- a/test/formats.js
+++ b/test/formats.js
@@ -295,6 +295,14 @@ describe('File formats', function () {
       });
     });
 
+    it('should ignore stroke-width', function () {
+      return probe(from2([
+        createBuffer('<svg stroke-width="2" width="5" height="4"></svg>')
+      ])).then(size => {
+        assert.deepEqual(size, { width: 5, height: 4, type: 'svg', mime: 'image/svg+xml', wUnits: 'px', hUnits: 'px' });
+      });
+    });
+
     /* eslint-disable max-nested-callbacks */
     describe('coverage', function () {
       it('too much data before doctype', function () {
@@ -375,7 +383,7 @@ describe('File formats', function () {
 
 
   describe('SVG (sync)', function () {
-    it('should detect PNG', function () {
+    it('should detect SVG', function () {
       var file = path.join(__dirname, 'fixtures', 'sample.svg');
       var size = probe.sync(toArray(fs.readFileSync(file)));
 
@@ -398,6 +406,12 @@ describe('File formats', function () {
       var size = probe.sync(toArray(createBuffer('<svg width="5in" height="4pt"></svg>')));
 
       assert.deepEqual(size, { width: 5, height: 4, type: 'svg', mime: 'image/svg+xml', wUnits: 'in', hUnits: 'pt' });
+    });
+
+    it('should ignore stroke-width', function () {
+      var size = probe.sync(toArray(createBuffer('<svg stroke-width="2" width="5" height="4"></svg>')));
+
+      assert.deepEqual(size, { width: 5, height: 4, type: 'svg', mime: 'image/svg+xml', wUnits: 'px', hUnits: 'px' });
     });
 
     describe('coverage', function () {


### PR DESCRIPTION
This change fixes the svg regular expression for width. The old re erroneously matches stroke-width in addition to width. 