### PR TITLE
Fix stream cleanup

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -46,7 +46,7 @@ module.exports = function probeStream(stream) {
 
   function cleanup() {
     // request stream doesn't have unpipe, https://github.com/request/request/issues/874
-    if (typeof stream.unpipe === 'function') stream.unpipe(this);
+    if (typeof stream.unpipe === 'function') stream.unpipe(proxy);
     proxy.end();
   }
 


### PR DESCRIPTION
In commit 0acaa785a55925a5310ad21166e0b66a32d6f67e, type checking for `stream.unpipe` was added.
But `stream.unpipe(proxy)` got changed to `stream.unpipe(this)` (typo?) and `this` in here is `undefined`, which leads to improper cleanup.
This commit reverts it to previous value.