### PR TITLE
svg: fix "push after EOF" error

### DIFF
--- a/lib/parse_stream/svg.js
+++ b/lib/parse_stream/svg.js
@@ -160,8 +160,8 @@ module.exports = function () {
           var result = parseSvg(str);
 
           if (result) {
-            parser.push(result);
             state = STATE_IGNORE;
+            parser.push(result);
             parser.push(null);
             break;
           }

--- a/lib/parse_stream/svg.js
+++ b/lib/parse_stream/svg.js
@@ -161,6 +161,7 @@ module.exports = function () {
 
           if (result) {
             parser.push(result);
+            state = STATE_IGNORE;
             parser.push(null);
             break;
           }

--- a/test/test_stream.js
+++ b/test/test_stream.js
@@ -95,4 +95,16 @@ describe('probeStream', function () {
       /unrecognized file format/
     );
   });
+
+  it('should not fail when processing svg in multiple chunks', async function () {
+    let stream = new Readable({
+      read: function () {
+        this.push('<?xml version="1.0" encoding="UTF-8"?><svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">');
+        this.push('</svg>');
+        this.push(null);
+      }
+    });
+
+    await probe(stream);
+  });
 });


### PR DESCRIPTION
Fixes #52.

Also adds test case which fails without this patch:
```
  1) probeStream
       should not fail when processing svg in multiple chunks:
     Uncaught Error [ERR_STREAM_PUSH_AFTER_EOF]: stream.push() after EOF
  2) probeStream
       should not fail when processing svg in multiple chunks:
     Error: done() called multiple times in test <probeStream should not fail when processing svg in multiple chunks> of file probe-image-size/test/test_stream.js
```
