### PR TITLE
Make probeStream accept an options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = function get_image_size(src, options) {
 
   if (typeof src.on === 'function' && typeof src.emit === 'function') {
     // looks like an EventEmitter, treating it as a stream
-    return probeStream(src, options);
+    return probeStream(src, options || {});
   }
 
   // HTTP (not stream)

--- a/stream.js
+++ b/stream.js
@@ -7,7 +7,8 @@ var PassThrough = require('stream').PassThrough;
 var pipeline    = require('stream').pipeline;
 
 
-module.exports = function probeStream(src, keepOpen) {
+module.exports = function probeStream(src, options) {
+  var keepOpen = options.keepOpen;
   var proxy = new PassThrough();
 
   // increase max number of listeners to stop memory leak warning


### PR DESCRIPTION
To keep these interfaces consistent, let's make probeStream accept an options object with 'keepOpen' as a property

Fixes #66