### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ '12', '14', '16' ]
+        node-version: [ '18', '20', '22' ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         check-latest: true
@@ -33,6 +33,6 @@ jobs:
       run: npm run report-coveralls
 
     - name: Upload coverage report to coveralls.io
-      uses: coverallsapp/github-action@v1.1.2
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflow to use the latest versions of actions and Node.js.

## Changes
- Update `actions/checkout` from v2 to v4
- Update `actions/setup-node` from v2 to v4  
- Update Node.js test matrix from 12,14,16 to 18,20,22
- Update `coverallsapp/github-action` from v1.1.2 to v2

## Motivation
- GitHub is deprecating Node.js 16 actions and older action versions
- Node.js 12, 14, and 16 are all end-of-life
- These updates ensure the CI continues working through 2025

## Testing
The updated workflow will run on this PR to verify everything works correctly with the new versions.